### PR TITLE
feat: improve internship validation and myInternships flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Backend Changelog
 
+## Unreleased
+
+### Added
+- Added `myInternships` GraphQL query in `api-gateway/src/graphql/type-defs.ts` and wired resolver in `api-gateway/src/graphql/resolvers/intership.ts` to fetch internships for the authenticated student.
+- Added stricter internship payload validation and date parsing in `student-management-api/src/handlers/internship-router.ts` (`parseDateOrThrow`, payload presence checks, and ID validation for required/optional numeric fields).
+- Added `phoneNumber` field mapping to internship and workplace job supervisor responses in `student-management-api/src/handlers/internship-router.ts` and `student-management-api/src/handlers/workplace-router.ts`.
+
+### Changed
+- Refactored GraphQL schema definition constant from `newLocal` to `typeDefs` and removed redundant aliasing before export in `api-gateway/src/graphql/type-defs.ts`.
+- Normalized GraphQL SDL formatting in `api-gateway/src/graphql/type-defs.ts` (argument spacing, field spacing, and trailing comma cleanup) to improve readability and consistency.
+- Renamed `deleteJobSupervisorResponse` to `DeleteJobSupervisorResponse` in `api-gateway/src/graphql/type-defs.ts` to follow PascalCase naming conventions.
+
 ## 20.01.2025
 
 ### Added

--- a/api-gateway/src/graphql/resolvers/intership.ts
+++ b/api-gateway/src/graphql/resolvers/intership.ts
@@ -4,6 +4,14 @@ const internships: Resolver<null, { studentId: number }> = async (_, args, conte
   return await context.dataSources.studentManagementAPI.getAllStudentInternships(args);
 }
 
+const myInternships: Resolver<null, Record<string, never>> = async (_, _args, context) => {
+  const studentId = context.user?.id;
+  if (!studentId) {
+    return { status: 401, success: false, internships: [] };
+  }
+  return await context.dataSources.studentManagementAPI.getAllStudentInternships({ studentId });
+};
+
 const createInternship = async (parent, args, context, info) => {
   return await context.dataSources.studentManagementAPI.createInternship(args)
 }
@@ -18,7 +26,8 @@ const editInternship = async (parent, args, context, info) => {
 
 export const Internship = {
   Query: {
-    internships
+    internships,
+    myInternships
   },
   Mutation: {
     createInternship,

--- a/api-gateway/src/graphql/type-defs.ts
+++ b/api-gateway/src/graphql/type-defs.ts
@@ -1,4 +1,4 @@
-const newLocal = `#graphql
+const typeDefs = `#graphql
     scalar DateTime
 
     directive @authenticated on FIELD_DEFINITION
@@ -112,11 +112,11 @@ const newLocal = `#graphql
         tags: [QualificationProjectTag!]!
     }
 
-    type WorktimeEntry{
+    type WorktimeEntry {
         startDate: DateTime
         endDate: DateTime
         description: String
-        id:ID
+        id: ID
     }
 
     type AssignedProjects {
@@ -163,7 +163,7 @@ const newLocal = `#graphql
         studyingQualificationTitle: QualificationTitle
         assignedQualificationUnits: [QualificationUnit!]
         assignedProjects: [AssignedProjects!]
-        assignedProjectSingle(projectId:ID!): AssignedProjectSingleResponse!
+        assignedProjectSingle(projectId: ID!): AssignedProjectSingleResponse!
     }
 
     type StudentForInternship {
@@ -322,7 +322,7 @@ const newLocal = `#graphql
     }
 
     type QualificationUnitForTeacher {
-        id: ID!,
+        id: ID!
         qualificationId: ID!
         name: String!
         scope: Int!
@@ -511,7 +511,7 @@ const newLocal = `#graphql
     type ChangeProjectStatusResponse {
         status: Int!
         success: Boolean!
-        message: String,
+        message: String
     }
 
     type UpdatePartOrderResponse {
@@ -549,20 +549,20 @@ const newLocal = `#graphql
     type WorktimeEntryResponse {
         success: Boolean!
         status: Int!
-        message: String!,
+        message: String!
         entry: WorktimeEntry!
     }
 
     type AssignedProjectSingleResponse { 
         success: Boolean!
         status: Int!
-        message: String,
-        project(projectId:ID!): AssignedProject
+        message: String
+        project(projectId: ID!): AssignedProject
     }
 
     type UpdateAssignedProjectResponse {
         success: Boolean!
-        status:Int!
+        status: Int!
         project: AssignedProject
     }
 
@@ -736,7 +736,7 @@ const newLocal = `#graphql
         createdJobSupervisor: JobSupervisorWithoutWorkplace
     }
 
-    type deleteJobSupervisorResponse {
+    type DeleteJobSupervisorResponse {
         success: Boolean!
         status: Int!
     }
@@ -864,7 +864,7 @@ const newLocal = `#graphql
         assignedTags(teacherId: ID!): AssignedTagsResponse! @authenticatedAsTeacher
         assignedProjects(id: ID!): AssignedProjectsResponse @authenticated
         assignedStudentProjects(studentId: ID!): AssignedProjectsResponse @authenticatedAsTeacher
-        # assignedProject(projectId:ID):AssignedProject @ authenticated
+        # assignedProject(projectId: ID): AssignedProject @authenticated
         notifications: NotificationsResponse! @authenticated
         notification(id: ID!): NotificationResponse! @authenticated
         unreadNotificationCount: UnreadNotificationCountResponse! @authenticated 
@@ -875,6 +875,7 @@ const newLocal = `#graphql
         workplaces: WorkplacesResponse! @authenticatedAsTeacher
         workplace(id: ID!): WorkplaceResponse! @authenticatedAsTeacher
         internships(studentId: ID!): InternshipsResponse! @authenticatedAsTeacher
+        myInternships: InternshipsResponse! @authenticatedAsStudent
         jobSupervisors: JobSupervisorsResponse! @authenticatedAsTeacher
         jobSupervisorsByWorkplace(workplaceId: ID!): JobSupervisorsWithWorkplaceResponse! @authenticatedAsTeacher
         jobSupervisor(jobSupervisorId: ID!): JobSupervisorResponse! @authenticatedAsTeacher
@@ -903,11 +904,11 @@ const newLocal = `#graphql
         updatePartOrder(unitId: ID!, partOrder: [ID!]!): GenericResponse! @authenticatedAsTeacher
         createProjectTag(name: String!): CreateProjectTagResponse! @authenticatedAsTeacher
         createProjectTags(names: [String!]!): ProjectTagsResponse! @authenticatedAsTeacher
-        assignProjectToStudent(studentId: ID! , projectId:ID! ): GenericResponse!  @authenticated
-        updateStudentProject(studentId: ID! , projectId:ID!, update: UpdateStudentProjectInput!) : GenericResponse @authenticated
-        unassignProjectFromStudent(studentId:ID! , projectId:ID!) : GenericResponse   @authenticated
-        createWorktimeEntry(studentId:ID! , projectId:ID!, entry: StudentWorktimeInput): WorktimeEntryResponse @authenticated
-        deleteWorktimeEntry(id:ID!): WorktimeEntryResponse @authenticated
+        assignProjectToStudent(studentId: ID!, projectId: ID!): GenericResponse! @authenticated
+        updateStudentProject(studentId: ID!, projectId: ID!, update: UpdateStudentProjectInput!): GenericResponse @authenticated
+        unassignProjectFromStudent(studentId: ID!, projectId: ID!): GenericResponse @authenticated
+        createWorktimeEntry(studentId: ID!, projectId: ID!, entry: StudentWorktimeInput): WorktimeEntryResponse @authenticated
+        deleteWorktimeEntry(id: ID!): WorktimeEntryResponse @authenticated
         markNotificationAsRead(id: ID!): MarkNotificationAsReadResponse! @authenticated
         
         # remove once not needed
@@ -937,19 +938,17 @@ const newLocal = `#graphql
         unassignJobSupervisor(workplaceId: ID!, jobSupervisorId: ID!): UnassignJobSupervisorResponse! @authenticatedAsTeacher
         updateJobSupervisorAssigns(workplaceId: ID!, assignIds: [ID!]!, unassignIds: [ID!]!): UpdateJobSupervisorAssignsResponse! @authenticatedAsTeacher
         createJobSupervisor(jobSupervisor: JobSupervisorInput!): CreateJobSupervisorResponse! @authenticatedAsTeacher
-        deleteJobSupervisor(id: ID!): deleteJobSupervisorResponse! @authenticatedAsTeacher
+        deleteJobSupervisor(id: ID!): DeleteJobSupervisorResponse! @authenticatedAsTeacher
         editJobSupervisor(id: ID!, jobSupervisor: JobSupervisorInput!): EditJobSupervisorResponse @authenticatedAsTeacher
 
         createInternship(internship: InternshipInput): CreateInternshipResponse! @authenticatedAsTeacher
         deleteInternship(internshipId: ID!): DeleteInternshipResponse! @authenticatedAsTeacher
         editInternship(internshipId: ID!, internship: InternshipInput!): EditInternshipResponse! @authenticatedAsTeacher
 
-        updateTeachingQualificationUnitAssigns(teacherId: ID!, assignQualificationUnitIds: [ID!]!, unassignQualificationUnitIds: [ID!]! ): UpdateTeachingQualificationUnitsResponse! @authenticatedAsTeacher
+        updateTeachingQualificationUnitAssigns(teacherId: ID!, assignQualificationUnitIds: [ID!]!, unassignQualificationUnitIds: [ID!]!): UpdateTeachingQualificationUnitsResponse! @authenticatedAsTeacher
     }
 
     # --- End of Query & Mutation ---
 
 `
-const typeDefs = newLocal
-
 export default typeDefs

--- a/student-management-api/src/handlers/internship-router.ts
+++ b/student-management-api/src/handlers/internship-router.ts
@@ -3,10 +3,24 @@ import prisma, { type Internship } from "prisma-orm";
 import { parseId } from "../utils/middleware.js";
 import type { RequestWithId } from "../types.js";
 import { checkIds, NeededType } from "../utils/checkIds.js";
+import { HttpError } from "../classes/HttpError.js";
 
 const router = express();
 
 type InternshipWithoutId = Omit<Internship, "id">
+
+const parseDateOrThrow = (value: unknown, fieldName: string): Date | null => {
+  if (value === null || value === undefined || value === "") return null;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) throw new HttpError(400, `${fieldName} is not a valid date`);
+    return value;
+  }
+
+  if (typeof value !== "string") throw new HttpError(400, `${fieldName} must be a string`);
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) throw new HttpError(400, `${fieldName} is not a valid date`);
+  return d;
+}
 
 router.get("/:id", parseId, async (req: RequestWithId, res, next) => {
   try {
@@ -41,6 +55,7 @@ router.get("/:id", parseId, async (req: RequestWithId, res, next) => {
           firstName: internship.jobSupervisor.users.firstName || null,
           lastName: internship.jobSupervisor.users.lastName || null,
           email: internship.jobSupervisor.users.email || null,
+          phoneNumber: internship.jobSupervisor.users.phoneNumber || null,
         } : null,
       } : null,
       teacher: internship.teacher ? {
@@ -67,11 +82,19 @@ router.get("/:id", parseId, async (req: RequestWithId, res, next) => {
 
 router.post("/", async (req, res, next) => {
   try {
-    const { startDate, endDate, info, workplaceId, teacherId, studentId, jobSupervisorId, qualificationUnitId } = req.body.internship
+    const internship = req.body?.internship
+    if (!internship) throw new HttpError(400, "internship payload missing")
+
+    const { startDate, endDate, info, workplaceId, teacherId, studentId, jobSupervisorId, qualificationUnitId } = internship
+
+    checkIds({ studentId, workplaceId }, NeededType.NUMBER)
+    if (jobSupervisorId !== null && jobSupervisorId !== undefined && jobSupervisorId !== "") checkIds({ jobSupervisorId }, NeededType.NUMBER)
+    if (teacherId !== null && teacherId !== undefined && teacherId !== "") checkIds({ teacherId }, NeededType.NUMBER)
+    if (qualificationUnitId !== null && qualificationUnitId !== undefined && qualificationUnitId !== "") checkIds({ qualificationUnitId }, NeededType.NUMBER)
 
     const parsedInternship: InternshipWithoutId = {
-      startDate: new Date(startDate) || null,
-      endDate: new Date(endDate) || null,
+      startDate: parseDateOrThrow(startDate, "startDate"),
+      endDate: parseDateOrThrow(endDate, "endDate"),
       info: info || null,
       workplaceId: workplaceId ? Number(workplaceId) : null,
       teacherUserId: teacherId ? Number(teacherId) : null,
@@ -113,11 +136,19 @@ router.delete("/:id", parseId, async (req: RequestWithId, res, next) => {
 
 router.put("/:id", parseId, async (req: RequestWithId, res, next) => {
   try {
-    const { startDate, endDate, info, workplaceId, teacherId, studentId, jobSupervisorId, qualificationUnitId } = req.body.internship
+    const internship = req.body?.internship
+    if (!internship) throw new HttpError(400, "internship payload missing")
+
+    const { startDate, endDate, info, workplaceId, teacherId, studentId, jobSupervisorId, qualificationUnitId } = internship
+
+    checkIds({ studentId, workplaceId }, NeededType.NUMBER)
+    if (jobSupervisorId !== null && jobSupervisorId !== undefined && jobSupervisorId !== "") checkIds({ jobSupervisorId }, NeededType.NUMBER)
+    if (teacherId !== null && teacherId !== undefined && teacherId !== "") checkIds({ teacherId }, NeededType.NUMBER)
+    if (qualificationUnitId !== null && qualificationUnitId !== undefined && qualificationUnitId !== "") checkIds({ qualificationUnitId }, NeededType.NUMBER)
 
     const parsedInternship: InternshipWithoutId = {
-      startDate: new Date(startDate) || null,
-      endDate: new Date(endDate) || null,
+      startDate: parseDateOrThrow(startDate, "startDate"),
+      endDate: parseDateOrThrow(endDate, "endDate"),
       info: info || null,
       workplaceId: workplaceId ? Number(workplaceId) : null,
       teacherUserId: teacherId ? Number(teacherId) : null,

--- a/student-management-api/src/handlers/workplace-router.ts
+++ b/student-management-api/src/handlers/workplace-router.ts
@@ -257,6 +257,7 @@ router.get("/:id/jobSupervisors", parseId, async (req: RequestWithId, res, next)
       firstName: jobSupervisor.users.firstName,
       lastName: jobSupervisor.users.lastName,
       email: jobSupervisor.users.email,
+      phoneNumber: jobSupervisor.users.phoneNumber || null,
     }))
 
     res.json({


### PR DESCRIPTION
## Summary
- Added `myInternships` support in GraphQL API for authenticated students.
- Extended internship/job supervisor response mapping to include `phoneNumber`.
- Hardened internship create/update handlers with stricter payload checks:
  - required payload validation
  - numeric ID validation for required and optional FK fields
  - safe date parsing with clear 400-level errors for invalid dates
- Refactored GraphQL schema file for clarity:
  - renamed schema constant to `typeDefs`
  - normalized SDL formatting
## Why
- Didn't work before
- Prevents invalid internship payloads from reaching DB layer and causing unclear runtime failures.
- Ensures frontend gets complete supervisor contact data (`email` + `phoneNumber`) from internship/workplace responses.
- Improves schema maintainability and consistency in GraphQL type definitions.
