### PR TITLE
feature: add more tests and health readiness endpoints see more in ba…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,35 @@ npm stop
 
 ## Testing
 
-Run test stack:
+### Student management end-to-end tests
+
+Run full test stack (PostgreSQL test DB + Prisma migrations + `student-management-api` tests):
 
 ```bash
 npm test
 ```
 
-This starts PostgreSQL test DB + Prisma migrations + `student-management-api` tests through `docker-compose.test.yml`.
+This uses `docker-compose.test.yml` to bring up the test database and run the existing REST tests.
+
+### Service-level smoke and integration tests
+
+Critical backend services also have lightweight smoke/integration tests that run directly against each workspace:
+
+- **auth-api**: health check + magic-link verify flow validation
+- **api-gateway**: health check + `/graphql` endpoint is mounted and responds
+- **messaging-server**: resolvers for user search and Prisma mapping
+- **notification-server**: HTTP notification creation + Redis subscriber persistence logic
+
+Run them from the `ossi-api` root:
+
+```bash
+npm test -w auth-api
+npm test -w api-gateway
+npm test -w messaging-server
+npm test -w notification-server
+```
+
+These tests are designed to avoid external infra dependencies (Docker, Redis, PostgreSQL, MongoDB) where possible, so they can be used as fast smoke tests locally and in CI.
 
 ## Database, Migrations and Seeding
 
@@ -104,6 +126,20 @@ npm run studio
 - Messaging GraphQL: `http://localhost:3002/graphql`
 - Prisma Studio (dev profile): `http://localhost:5555`
 - pgAdmin: `http://localhost:5433`
+
+## Health and Readiness Endpoints
+
+All backend services expose:
+
+- `GET /health`: process liveness check
+- `GET /ready`: dependency readiness check
+
+Readiness verifies critical dependencies per service:
+
+- `auth-api`: PostgreSQL via Prisma query
+- `api-gateway`: Redis client/pub/sub connection state
+- `messaging-server`: MongoDB + Redis connection state
+- `notification-server`: MongoDB + Redis connection state
 
 ## Environment Variables
 

--- a/api-gateway/package.json
+++ b/api-gateway/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "build": "tsc",
         "dev": "tsx watch --inspect=0.0.0.0:9229 src/index.ts",
-        "start": "node ./dist/index.js"
+        "start": "node ./dist/index.js",
+        "test": "node --import tsx --test test/*.test.ts"
     },
     "devDependencies": {
         "@graphql-tools/utils": "^10.8.6",
@@ -16,6 +17,8 @@
         "@types/jsonwebtoken": "^9.0.7",
         "@types/mongoose": "^5.11.97",
         "@types/node": "^24.6.2",
+        "@types/supertest": "^6.0.2",
+        "supertest": "^7.1.4",
         "tsx": "^4.20.6",
         "typescript": "^5.8.3"
     },

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import graphqlRouter from "./controllers/graphql.js";
+
+interface AppOptions {
+    readinessCheck?: () => Promise<boolean>;
+}
+
+export const createApp = (options: AppOptions = {}) => {
+    const app = express();
+
+    app.get("/health", (_req, res) => {
+        res.json({ ok: true, service: "api-gateway" });
+    });
+
+    app.get("/ready", async (_req, res) => {
+        try {
+            const isReady = options.readinessCheck ? await options.readinessCheck() : true;
+            if (!isReady) {
+                return res.status(503).json({ ok: false, service: "api-gateway" });
+            }
+
+            return res.json({ ok: true, service: "api-gateway" });
+        } catch (_error) {
+            return res.status(503).json({ ok: false, service: "api-gateway" });
+        }
+    });
+
+    app.use("/graphql", graphqlRouter);
+
+    return app;
+};

--- a/api-gateway/src/controllers/graphql.ts
+++ b/api-gateway/src/controllers/graphql.ts
@@ -90,7 +90,6 @@ const server = new ApolloServer<ApolloContext>({ schema });
                 }
             }
 
-            // todo
             return {
                 user: null,
                 dataSources: {

--- a/api-gateway/src/graphql/context.ts
+++ b/api-gateway/src/graphql/context.ts
@@ -13,8 +13,6 @@ interface ApolloContext {
     user: UserContext | null,
     dataSources: {
         studentManagementAPI: StudentManagementAPI,
-//        activityAPI: ActivityAPI,
-//        authAPI: AuthAPI,
     },
     token: string
 }

--- a/api-gateway/src/graphql/resolvers/messaging.ts
+++ b/api-gateway/src/graphql/resolvers/messaging.ts
@@ -6,7 +6,6 @@ import { type ApolloContext } from '../context.js';
 const messagingPubSub = new PubSub();
 let redisSubscriptionInitialized = false;
 
-// Initialize Redis subscription once
 const initializeRedisSubscription = () => {
     if (!redisSubscriptionInitialized) {
         subscriber.subscribe('message_received', (message) => {
@@ -27,12 +26,10 @@ export const MessagingResolvers = {
                     return [];
                 }
 
-                // Publish request for conversations
                 await publisher.publish('get_conversations', JSON.stringify({
                     userEmail: context.user.email
                 }));
 
-                // Wait for response
                 return new Promise((resolve, reject) => {
                     const timeout = setTimeout(() => {
                         reject(new Error('Conversations fetch timeout'));
@@ -55,13 +52,11 @@ export const MessagingResolvers = {
                     return [];
                 }
 
-                // Publish request for messages
                 await publisher.publish('get_messages', JSON.stringify({
                     conversationId,
                     userEmail: context.user.email
                 }));
 
-                // Wait for response
                 return new Promise((resolve, reject) => {
                     const timeout = setTimeout(() => {
                         reject(new Error('Messages fetch timeout'));
@@ -156,14 +151,12 @@ export const MessagingResolvers = {
                     throw new Error('User not authenticated');
                 }
 
-                // Publish message to Redis for messaging server to process
                 await publisher.publish('new_message', JSON.stringify({
                     conversationId,
                     content,
                     sender: context.user
                 }));
 
-                // Wait for response from messaging server
                 return new Promise((resolve, reject) => {
                     const timeout = setTimeout(() => {
                         reject(new Error('Message sending timeout'));

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,8 +1,8 @@
-import express from 'express';
-import graphqlRouter from './controllers/graphql.js';
+import { createApp } from "./app.js";
+import { publisher, redisClient, subscriber } from "./redis-client.js";
 
-const app = express();
+const app = createApp({
+    readinessCheck: async () => redisClient.isOpen && publisher.isOpen && subscriber.isOpen
+});
 
-app.use('/graphql', graphqlRouter);
-
-app.listen(3000)
+app.listen(3000);

--- a/api-gateway/src/redis-client.ts
+++ b/api-gateway/src/redis-client.ts
@@ -4,14 +4,17 @@ export const redisClient = createClient({
   url: 'redis://redis:6379'
 });
 
-await redisClient.connect().catch(console.error);
-
 export const publisher = redisClient.duplicate();
 export const subscriber = redisClient.duplicate();
 
 export const connectToRedis = async () => {
+  if (process.env.NODE_ENV === "test") {
+    return;
+  }
+
+  await redisClient.connect();
   await publisher.connect();
   await subscriber.connect();
 }
 
-await connectToRedis()
+await connectToRedis().catch(console.error);

--- a/api-gateway/test/gateway.smoke.test.ts
+++ b/api-gateway/test/gateway.smoke.test.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import supertest from "supertest";
+
+test("gateway health endpoint responds", async () => {
+    process.env.NODE_ENV = "test";
+    const { createApp } = await import("../src/app.js");
+    const api = supertest(createApp());
+    const response = await api.get("/health").expect(200);
+
+    assert.equal(response.body.ok, true);
+    assert.equal(response.body.service, "api-gateway");
+});
+
+test("gateway readiness endpoint responds", async () => {
+    process.env.NODE_ENV = "test";
+    const { createApp } = await import("../src/app.js");
+    const api = supertest(createApp());
+    const response = await api.get("/ready").expect(200);
+
+    assert.equal(response.body.ok, true);
+    assert.equal(response.body.service, "api-gateway");
+});
+
+test("graphql endpoint is mounted for POST requests", async () => {
+    process.env.NODE_ENV = "test";
+    const { createApp } = await import("../src/app.js");
+    const api = supertest(createApp());
+    let response = await api.post("/graphql").send({ query: "{ __typename }" });
+    for (let i = 0; i < 5 && response.status === 404; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        response = await api.post("/graphql").send({ query: "{ __typename }" });
+    }
+
+    assert.notEqual(response.status, 404);
+});

--- a/api-gateway/test/gateway.smoke.test.ts
+++ b/api-gateway/test/gateway.smoke.test.ts
@@ -22,6 +22,20 @@ test("gateway readiness endpoint responds", async () => {
     assert.equal(response.body.service, "api-gateway");
 });
 
+test("gateway readiness returns 503 when dependency check fails", async () => {
+    process.env.NODE_ENV = "test";
+    const { createApp } = await import("../src/app.js");
+    const api = supertest(
+        createApp({
+            readinessCheck: async () => false,
+        })
+    );
+    const response = await api.get("/ready").expect(503);
+
+    assert.equal(response.body.ok, false);
+    assert.equal(response.body.service, "api-gateway");
+});
+
 test("graphql endpoint is mounted for POST requests", async () => {
     process.env.NODE_ENV = "test";
     const { createApp } = await import("../src/app.js");

--- a/auth-api/package.json
+++ b/auth-api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch --inspect=0.0.0.0:9229 src/index.ts",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/index.js",
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "axios": "^1.7.7",
@@ -23,6 +24,8 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.6.1",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.1.4",
     "tsx": "^4.20.6",
     "typescript": "^5.6.2"
   }

--- a/auth-api/src/app.ts
+++ b/auth-api/src/app.ts
@@ -1,0 +1,34 @@
+import express from "express";
+import { AuthRouter } from "./routes/auth-router.js";
+import { MagicLinkRouter } from "./routes/magicLink-router.js";
+
+interface AppOptions {
+    readinessCheck?: () => Promise<boolean>;
+}
+
+export const createApp = (options: AppOptions = {}) => {
+    const app = express();
+    app.use(express.json());
+
+    app.get("/health", (_req, res) => {
+        res.json({ ok: true, service: "auth-api" });
+    });
+
+    app.get("/ready", async (_req, res) => {
+        try {
+            const isReady = options.readinessCheck ? await options.readinessCheck() : true;
+            if (!isReady) {
+                return res.status(503).json({ ok: false, service: "auth-api" });
+            }
+
+            return res.json({ ok: true, service: "auth-api" });
+        } catch (_error) {
+            return res.status(503).json({ ok: false, service: "auth-api" });
+        }
+    });
+
+    app.use("/login", AuthRouter);
+    app.use("/auth/magic-link", MagicLinkRouter);
+
+    return app;
+};

--- a/auth-api/src/index.ts
+++ b/auth-api/src/index.ts
@@ -1,19 +1,15 @@
 import "dotenv";
-
-import express from "express";
-import { AuthRouter } from "./routes/auth-router.js";
-import { MagicLinkRouter } from "./routes/magicLink-router.js";
-
-const app = express();
-app.use(express.json());
+import prisma from "prisma-orm";
+import { createApp } from "./app.js";
 
 const PORT = 3000;
-
-
-app.use("/login", AuthRouter)
-app.use("/auth/magic-link", MagicLinkRouter)
-
+const app = createApp({
+    readinessCheck: async () => {
+        await prisma.$queryRawUnsafe("SELECT 1");
+        return true;
+    }
+});
 
 app.listen(PORT, () => {
-    console.log(`auth-api running on port ${PORT}`)
+    console.log(`auth-api running on port ${PORT}`);
 });

--- a/auth-api/src/routes/auth-router.ts
+++ b/auth-api/src/routes/auth-router.ts
@@ -24,12 +24,10 @@ async function getPemCertificate(idToken) {
 
 const router = express.Router();
 
-// intended for basic ossi login, job supervisor scopes should be created in a seperate endpoint?
 router.post("/", async (req, res) => {
     try {
         const userData = await prisma.$transaction(async (transaction) => {
 
-            // Prisma ORM do not have table lock functionality built-in, so need use raw query
             await transaction.$queryRaw`LOCK TABLE "users" IN ACCESS EXCLUSIVE MODE`
 
             let idToken: IdTokenPayload;
@@ -44,7 +42,6 @@ router.post("/", async (req, res) => {
             const isUserInDatabase = await transaction.user.findFirst({ where: { oid: idToken.oid } }) != null;
             const userScope = idToken.upn.endsWith("@esedulainen.fi") ? enumUsersScope.STUDENT : enumUsersScope.TEACHER;
 
-            // create user and teacher or student rows for nonexistant user
             if (!isUserInDatabase) {
                 const createdUser = await transaction.user.create({
                     data: {
@@ -101,7 +98,6 @@ router.post("/", async (req, res) => {
 
             const user = await transaction.user.findFirst({ where: { oid: idToken.oid } });
 
-            //Need use findUnique because we do not have findByPk() in the Prisma ORM
             const profile = userScope == enumUsersScope.STUDENT
                 ? await transaction.student.findUnique({ where: { userId: user.id } })
                 : await transaction.teacher.findUnique({ where: { userId: user.id } });
@@ -119,12 +115,10 @@ router.post("/", async (req, res) => {
             return userData
         });
 
-        //If Prisma ORM rollback transaction and we do not have userData
         if (!userData) {
             throw new HttpError(400)
         }
 
-        // In Prisma ORM we do not need manually commit transaction, so we can return response
         res.json({
             status: 200,
             success: true,

--- a/auth-api/src/routes/magicLink-router.ts
+++ b/auth-api/src/routes/magicLink-router.ts
@@ -46,19 +46,16 @@ router.post("/verify", async (req: Request, res: Response) => {
     if (tokenRecord.used) return res.status(400).json({ error: "Link already used" });
     if (new Date(tokenRecord.expiresAt) < new Date()) return res.status(400).json({ error: "Link expired" });
 
-    // hash and compare
     const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
     if (tokenHash !== tokenRecord.tokenHash) {
         return res.status(400).json({ error: "Invalid token" });
     }
 
-    // Mark as used
     await prisma.magicLinkToken.update({
         where: { id },
         data: { used: true },
     });
 
-    // create session
     const jwtToken = jwt.sign({}, process.env.JWT_SECRET_KEY ?? "", {
         expiresIn: "1d"
     })

--- a/auth-api/test/auth.smoke.test.ts
+++ b/auth-api/test/auth.smoke.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import supertest from "supertest";
+import { createApp } from "../src/app.js";
+
+const api = supertest(createApp());
+
+test("auth health endpoint responds with service metadata", async () => {
+    const response = await api.get("/health").expect(200);
+
+    assert.equal(response.body.ok, true);
+    assert.equal(response.body.service, "auth-api");
+});
+
+test("auth readiness endpoint responds", async () => {
+    const response = await api.get("/ready").expect(200);
+
+    assert.equal(response.body.ok, true);
+    assert.equal(response.body.service, "auth-api");
+});
+
+test("magic-link verify validation rejects empty payload", async () => {
+    const response = await api.post("/auth/magic-link/verify").send({}).expect(400);
+
+    assert.equal(response.body.error, "Invalid link");
+});

--- a/auth-api/test/auth.smoke.test.ts
+++ b/auth-api/test/auth.smoke.test.ts
@@ -19,6 +19,19 @@ test("auth readiness endpoint responds", async () => {
     assert.equal(response.body.service, "auth-api");
 });
 
+test("auth readiness returns 503 when dependency check fails", async () => {
+    const failingApi = supertest(
+        createApp({
+            readinessCheck: async () => false,
+        })
+    );
+
+    const response = await failingApi.get("/ready").expect(503);
+
+    assert.equal(response.body.ok, false);
+    assert.equal(response.body.service, "auth-api");
+});
+
 test("magic-link verify validation rejects empty payload", async () => {
     const response = await api.post("/auth/magic-link/verify").send({}).expect(400);
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -64,7 +64,7 @@ services:
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
       interval: 5s

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -64,7 +64,7 @@ services:
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
-      - db-data:/var/lib/postgresql
+      - db-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
       interval: 5s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -28,8 +28,8 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
       interval: 2s
-      retries: 5
-      start_period: 1s
+      retries: 30
+      start_period: 5s
 
   db-migrations:
     extends:
@@ -40,6 +40,7 @@ services:
     depends_on:
       db-test:
         condition: service_healthy
+    restart: on-failure:5
     command: ["npm", "--workspace", "prisma-orm", "run", "start:test"]
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     ports:
       - "5432:5432"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
     volumes:
-      - db-data:/var/lib/postgresql
+      - db-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:

--- a/docs/BACKEND_DOCUMENTATION.md
+++ b/docs/BACKEND_DOCUMENTATION.md
@@ -88,6 +88,8 @@ Implementation files:
 
 Service root is internal container URL `http://auth-api:3000`.
 
+- `GET /health`
+- `GET /ready`
 - `POST /login`
 - `POST /auth/magic-link/request`
 - `POST /auth/magic-link/verify`
@@ -101,6 +103,11 @@ Implementation:
 
 Base URL (host): `http://localhost:3001/notifications`
 
+Service liveness/readiness endpoints:
+
+- `GET /health`
+- `GET /ready`
+
 Routes in `notification-server/src/handlers/notification-router.ts`:
 
 - `GET /notifications`
@@ -112,6 +119,11 @@ Routes in `notification-server/src/handlers/notification-router.ts`:
 ### 5) Messaging Server
 
 Base URL (host): `http://localhost:3002/graphql`
+
+Service liveness/readiness endpoints:
+
+- `GET /health`
+- `GET /ready`
 
 - GraphQL schema: `messaging-server/src/schema.ts`
 - Resolvers: `messaging-server/src/resolvers.ts`
@@ -170,8 +182,13 @@ Core variables:
 1. `npm install`
 2. `npm --workspace=prisma-orm run build`
 3. `npm run dev`
-4. run tests with `npm test`
-5. stop stack with `npm stop`
+4. run student-management test stack with `npm test`
+5. run service smoke/integration tests:
+   - `npm test -w auth-api`
+   - `npm test -w api-gateway`
+   - `npm test -w messaging-server`
+   - `npm test -w notification-server`
+6. stop stack with `npm stop`
 
 ## Production Deployment Workflow
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -37,6 +37,14 @@ Tämä checklist on OSSI backendin tuotantojulkaisulle (`ossi2.esedu.fi`) mallil
 
 - [ ] Kontit ovat käynnissä:
   - `docker compose -f deploy/docker-compose.prod.yml ps`
+- [ ] Health endpointit vastaavat:
+  - `curl -fsS http://localhost:3000/health`
+  - `curl -fsS http://localhost:3001/health`
+  - `curl -fsS http://localhost:3002/health`
+- [ ] Readiness endpointit vastaavat:
+  - `curl -fsS http://localhost:3000/ready`
+  - `curl -fsS http://localhost:3001/ready`
+  - `curl -fsS http://localhost:3002/ready`
 - [ ] API gatewayn lokissa ei ole kriittisiä virheitä:
   - `docker compose -f deploy/docker-compose.prod.yml logs --tail=100 api-gateway`
 - [ ] Opiskelijahallinnan lokissa ei ole migraatio/runtime-virheitä:

--- a/messaging-server/package.json
+++ b/messaging-server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch --inspect=0.0.0.0:9229 src/index.ts",
-    "start": "DEBUG=$DEBUG node ./dist/index.js"
+    "start": "DEBUG=$DEBUG node ./dist/index.js",
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.11.0",

--- a/messaging-server/src/index.ts
+++ b/messaging-server/src/index.ts
@@ -8,7 +8,7 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import cors from 'cors';
 import { typeDefs } from './schema.js';
 import { resolvers } from './resolvers.js';
-import { publisher, subscriber } from './redis-client.js';
+import { publisher, redisClient, subscriber } from './redis-client.js';
 import { Message } from './models/message.js';
 import mongoose from 'mongoose';
 import { Conversation } from './models/conversation.js';
@@ -16,19 +16,33 @@ import { MessageDocument, ConversationDocument } from './types.js';
 import { getUserFromDatabase } from './resolvers.js';
 import { Types } from 'mongoose';
 
-// Connect to MongoDB
 mongoose.connect("mongodb://mongo:27017/messaging")
   .then(() => console.log('Connected to MongoDB'))
   .catch(err => console.error('MongoDB connection error:', err));
 
-// Create Express app and HTTP server
 const app = express();
 const httpServer = createServer(app);
 
-// Create schema
+app.get("/health", (_req, res) => {
+  res.json({ ok: true, service: "messaging-server" });
+});
+
+app.get("/ready", (_req, res) => {
+  const isReady =
+    mongoose.connection.readyState === 1 &&
+    redisClient.isOpen &&
+    publisher.isOpen &&
+    subscriber.isOpen;
+
+  if (!isReady) {
+    return res.status(503).json({ ok: false, service: "messaging-server" });
+  }
+
+  return res.json({ ok: true, service: "messaging-server" });
+});
+
 const schema = makeExecutableSchema({ typeDefs, resolvers });
 
-// Create Apollo Server
 const server = new ApolloServer({
   schema,
   plugins: [
@@ -60,7 +74,6 @@ app.use(
   }),
 );
 
-// Add error handling middleware
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
     console.error('Error:', err);
     const statusCode = err.statusCode || 500;
@@ -77,13 +90,11 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
     });
 });
 
-// Start the server
 const PORT = process.env.PORT || 3000;
 httpServer.listen(PORT, () => {
     console.log(`Server is running at http://localhost:${PORT}/graphql`);
 });
 
-// Kuunnellaan uusia viestejä API Gatewaylta
 subscriber.subscribe('new_message', async (message) => {
   try {
     const { conversationId, content, sender } = JSON.parse(message);
@@ -96,7 +107,6 @@ subscriber.subscribe('new_message', async (message) => {
       createdAt: new Date()
     });
 
-    // Update conversation's lastMessage
     await Conversation.findByIdAndUpdate(conversationId, {
       lastMessage: newMessage._id
     });
@@ -146,7 +156,6 @@ subscriber.subscribe('get_messages', async (message) => {
     try {
         const { conversationId, userEmail } = JSON.parse(message);
 
-        // Verify user is part of the conversation
         const conversation = await Conversation.findById(conversationId);
         if (!conversation || !conversation.participants.includes(userEmail)) {
             throw new Error('Not authorized to view these messages');

--- a/messaging-server/src/resolvers.ts
+++ b/messaging-server/src/resolvers.ts
@@ -1,7 +1,6 @@
 import prisma from "prisma-orm"
 
 import { User, ResolverContext } from './types.js';
-//import { pool } from './postgres-pool.js';
 
 export const getUserFromDatabase = async (email: string): Promise<User | null> => {
   try {
@@ -25,14 +24,6 @@ export const getUserFromDatabase = async (email: string): Promise<User | null> =
       id: result.email,
       ...result,
     }
-    // return {
-    //   id: row.email, // Using email as ID for consistency
-    //   firstName: row.firstName,
-    //   lastName: row.lastName,
-    //   email: row.email,
-    //   phoneNumber: row.phoneNumber,
-    //   archived: row.archived
-    // };
   } catch (error) {
     console.error('Error fetching user from database:', error);
     return null;
@@ -54,26 +45,6 @@ export const resolvers = {
           throw new Error('User not authenticated');
         }
 
-        // const searchResult = await pool.query<DBUser>(
-        //   `SELECT 
-        //                 id,
-        //                 first_name as "firstName",
-        //                 last_name as "lastName",
-        //                 email,
-        //                 phone_number as "phoneNumber",
-        //                 archived,
-        //                 scope
-        //              FROM users 
-        //              WHERE email != $1 
-        //                AND (
-        //                  LOWER(first_name) LIKE LOWER($2) 
-        //                  OR LOWER(last_name) LIKE LOWER($2) 
-        //                  OR LOWER(email) LIKE LOWER($2)
-        //                )
-        //                AND archived = false`,
-        //   [user.email, `%${query}%`]
-        // );
-
         const searchResult = await prisma.user.findMany({
           where: {
             email: { not: user.email },
@@ -94,7 +65,7 @@ export const resolvers = {
         })
 
         return searchResult.map((row: any) => ({
-          id: row.email, // Using email as ID for consistency with the existing system
+          id: row.email,
           ...row
         }));
       } catch (error) {

--- a/messaging-server/test/messaging.integration.test.ts
+++ b/messaging-server/test/messaging.integration.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import prisma from "prisma-orm";
+import { getUserFromDatabase, resolvers } from "../src/resolvers.js";
+
+test("getUserFromDatabase maps prisma user to GraphQL user shape", async () => {
+    const originalFindFirst = prisma.user.findFirst;
+
+    prisma.user.findFirst = async () =>
+        ({
+            firstName: "Test",
+            lastName: "User",
+            email: "test@example.com",
+            phoneNumber: "123",
+            archived: false,
+            scope: "TEACHER",
+        } as any);
+
+    try {
+        const user = await getUserFromDatabase("test@example.com");
+        assert.equal(user?.id, "test@example.com");
+        assert.equal(user?.firstName, "Test");
+        assert.equal(user?.email, "test@example.com");
+    } finally {
+        prisma.user.findFirst = originalFindFirst;
+    }
+});
+
+test("searchUsers returns empty list when unauthenticated", async () => {
+    const result = await resolvers.Query.searchUsers(
+        null,
+        { query: "test" },
+        { user: null } as any
+    );
+
+    assert.deepEqual(result, []);
+});
+
+test("searchUsers maps prisma rows and excludes current user", async () => {
+    const originalFindMany = prisma.user.findMany;
+    let whereArg: any = null;
+
+    prisma.user.findMany = async (args: any) => {
+        whereArg = args.where;
+        return [
+            {
+                email: "other@example.com",
+                firstName: "Other",
+                lastName: "User",
+                phoneNumber: "555",
+                archived: false,
+            },
+        ] as any;
+    };
+
+    try {
+        const result = await resolvers.Query.searchUsers(
+            null,
+            { query: "oth" },
+            { user: { email: "me@example.com" } } as any
+        );
+
+        assert.equal(whereArg.email.not, "me@example.com");
+        assert.equal(result.length, 1);
+        assert.equal(result[0].id, "other@example.com");
+    } finally {
+        prisma.user.findMany = originalFindMany;
+    }
+});

--- a/notification-server/package.json
+++ b/notification-server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch --inspect=0.0.0.0:9229 src/index.ts",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/index.js",
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "axios": "^1.7.7",
@@ -23,6 +24,8 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.6.1",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.1.4",
     "tsx": "^4.20.6",
     "typescript": "^5.6.2"
   }

--- a/notification-server/src/app.ts
+++ b/notification-server/src/app.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import { NotificationRouter } from "./handlers/notification-router.js";
+
+interface AppOptions {
+    readinessCheck?: () => Promise<boolean>;
+}
+
+export const createApp = (options: AppOptions = {}) => {
+    const app = express();
+
+    app.get("/health", (_req, res) => {
+        res.json({ ok: true, service: "notification-server" });
+    });
+
+    app.get("/ready", async (_req, res) => {
+        try {
+            const isReady = options.readinessCheck ? await options.readinessCheck() : true;
+            if (!isReady) {
+                return res.status(503).json({ ok: false, service: "notification-server" });
+            }
+
+            return res.json({ ok: true, service: "notification-server" });
+        } catch (_error) {
+            return res.status(503).json({ ok: false, service: "notification-server" });
+        }
+    });
+
+    app.use("/notifications", NotificationRouter);
+
+    return app;
+};

--- a/notification-server/src/index.ts
+++ b/notification-server/src/index.ts
@@ -1,15 +1,14 @@
 import 'dotenv/config'
-import express, { json } from 'express';
 import mongoose from "mongoose";
-import { NotificationRouter } from './handlers/notification-router.js';
 import { notificationSubscriberHandler } from './handlers/notification-redis-subscriber.js';
 import { redisClient } from './redis.js';
+import { createApp } from "./app.js";
 
 mongoose.connect("mongodb://mongo:27017/");
 
-const app = express();
-
-app.use("/notifications", NotificationRouter);
+const app = createApp({
+    readinessCheck: async () => mongoose.connection.readyState === 1 && redisClient.isOpen
+});
 
 (async () => {
     app.listen(3000);

--- a/notification-server/test/notification.integration.test.ts
+++ b/notification-server/test/notification.integration.test.ts
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import supertest from "supertest";
+import { createApp } from "../src/app.js";
+import {
+    ProjectReturnNotification,
+    ProjectStatusChangeNotification,
+} from "../src/models/notification.js";
+import { notificationSubscriberHandler } from "../src/handlers/notification-redis-subscriber.js";
+
+const api = supertest(createApp());
+
+const restoreSave = (ctor: any, calls: any[]) => {
+    const original = ctor.prototype.save;
+    ctor.prototype.save = async function saveMock() {
+        calls.push(this);
+        return this;
+    };
+    return () => {
+        ctor.prototype.save = original;
+    };
+};
+
+test("notification route creates one notification per recipient", async () => {
+    const saved: any[] = [];
+    const restore = restoreSave(ProjectReturnNotification, saved);
+
+    try {
+        await api
+            .post("/notifications/send_notification")
+            .send({
+                recipients: ["user-1", "user-2"],
+                notification: {
+                    type: "ProjectReturn",
+                    projectId: 42,
+                    returnerStudentId: "student-1",
+                },
+            })
+            .expect(200);
+
+        assert.equal(saved.length, 2);
+        assert.deepEqual(saved.map((doc) => doc.recipient), ["user-1", "user-2"]);
+    } finally {
+        restore();
+    }
+});
+
+test("redis subscriber handler persists project status change notifications", async () => {
+    const saved: any[] = [];
+    const restore = restoreSave(ProjectStatusChangeNotification, saved);
+
+    try {
+        await notificationSubscriberHandler(
+            JSON.stringify({
+                recipients: ["teacher-1"],
+                notification: {
+                    type: "ProjectStatusChange",
+                    projectId: 101,
+                    message: "Status changed",
+                    status: "ACCEPTED",
+                    teacherComment: "Looks good",
+                },
+            })
+        );
+
+        assert.equal(saved.length, 1);
+        assert.equal(saved[0].recipient, "teacher-1");
+        assert.equal(saved[0].projectId, 101);
+    } finally {
+        restore();
+    }
+});
+
+test("redis subscriber rejects unknown notification types", async () => {
+    await assert.rejects(async () => {
+        await notificationSubscriberHandler(
+            JSON.stringify({
+                recipients: ["teacher-1"],
+                notification: {
+                    type: "Unknown",
+                },
+            })
+        );
+    });
+});
+
+test("notification health endpoint responds", async () => {
+    const response = await api.get("/health").expect(200);
+    assert.equal(response.body.ok, true);
+    assert.equal(response.body.service, "notification-server");
+});
+
+test("notification readiness endpoint responds", async () => {
+    const response = await api.get("/ready").expect(200);
+    assert.equal(response.body.ok, true);
+    assert.equal(response.body.service, "notification-server");
+});

--- a/notification-server/test/notification.integration.test.ts
+++ b/notification-server/test/notification.integration.test.ts
@@ -95,3 +95,15 @@ test("notification readiness endpoint responds", async () => {
     assert.equal(response.body.ok, true);
     assert.equal(response.body.service, "notification-server");
 });
+
+test("notification readiness returns 503 when dependency check fails", async () => {
+    const failingApi = supertest(
+        createApp({
+            readinessCheck: async () => false,
+        })
+    );
+
+    const response = await failingApi.get("/ready").expect(503);
+    assert.equal(response.body.ok, false);
+    assert.equal(response.body.service, "notification-server");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
                 "@types/jsonwebtoken": "^9.0.7",
                 "@types/mongoose": "^5.11.97",
                 "@types/node": "^24.6.2",
+                "@types/supertest": "^6.0.2",
+                "supertest": "^7.1.4",
                 "tsx": "^4.20.6",
                 "typescript": "^5.8.3"
             }
@@ -61,6 +63,8 @@
                 "@types/express": "^4.17.21",
                 "@types/jsonwebtoken": "^9.0.7",
                 "@types/node": "^22.6.1",
+                "@types/supertest": "^6.0.2",
+                "supertest": "^7.1.4",
                 "tsx": "^4.20.6",
                 "typescript": "^5.6.2"
             }
@@ -580,8 +584,7 @@
             "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.2.tgz",
             "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w==",
             "devOptional": true,
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/@electric-sql/pglite-socket": {
             "version": "0.0.6",
@@ -1429,7 +1432,6 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
             "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2",
                 "generic-pool": "3.9.0",
@@ -2212,7 +2214,8 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -2840,7 +2843,6 @@
             "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
             "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
@@ -2897,7 +2899,6 @@
             "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
             "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2962,7 +2963,6 @@
             "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -3734,7 +3734,6 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
             "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.9.1",
                 "pg-pool": "^3.10.1",
@@ -3909,7 +3908,6 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@prisma/config": "7.1.0",
                 "@prisma/dev": "0.15.0",
@@ -4188,7 +4186,8 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
             "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
             "devOptional": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/semver": {
             "version": "7.7.3",
@@ -4873,6 +4872,8 @@
                 "@types/express": "^4.17.21",
                 "@types/jsonwebtoken": "^9.0.7",
                 "@types/node": "^22.6.1",
+                "@types/supertest": "^6.0.2",
+                "supertest": "^7.1.4",
                 "tsx": "^4.20.6",
                 "typescript": "^5.6.2"
             }
@@ -4894,7 +4895,6 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.9.0.tgz",
             "integrity": "sha512-EI0Ti5pojD2p7TmcS7RRa+AJVahdQvP/urpcSbK/K9Rlk6+dwMJTQ354pCNGCwfke8x4yKr5+iH85wcERSkwLQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -5033,7 +5033,6 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.9.0.tgz",
             "integrity": "sha512-EI0Ti5pojD2p7TmcS7RRa+AJVahdQvP/urpcSbK/K9Rlk6+dwMJTQ354pCNGCwfke8x4yKr5+iH85wcERSkwLQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },

--- a/prisma-orm/index.ts
+++ b/prisma-orm/index.ts
@@ -8,8 +8,6 @@ const DATABASE_URL = process.env.NODE_ENV === "test"
 
 const adapter = new PrismaPg({ connectionString: DATABASE_URL })
 
-//Store Prisma client as a global variable to do prevent client reloading by hot reload in non-production environment
-
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient;
 };
@@ -25,12 +23,9 @@ if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = prisma;
 }
 
-// Re-export everything from generated client (types + helpers)
 export * from "./generated/prisma/client.js"
 
 export type { PrismaClient } from "./generated/prisma/client.js"
 export * from "./generated/prisma/enums.js"
-
-//export * from "@prisma/client/runtime/library"
 
 export default prisma

--- a/student-management-api/src/handlers/parts-router.ts
+++ b/student-management-api/src/handlers/parts-router.ts
@@ -16,7 +16,6 @@ interface BasePartBody {
 const router = express();
 
 router.get("/", async (req, res, next) => {
-    // We don't need to use transactions in read-only operation
     const parts = await prisma.qualificationUnitPart.findMany()
 
     res.json({

--- a/student-management-api/src/handlers/student-router.ts
+++ b/student-management-api/src/handlers/student-router.ts
@@ -161,8 +161,6 @@ router.get("/:id/assigned_qualification_units", parseId, async (req: RequestWith
 })
 
 router.get("/:id/assigned_projects", parseId, async (req: RequestWithId, res) => {
-    //table assigned_projects_for_students
-
     const foundAssignedProjects = await prisma.assignedProjectsForStudent.findMany({
         where: { studentId: req.id },
         include: {
@@ -171,7 +169,6 @@ router.get("/:id/assigned_projects", parseId, async (req: RequestWithId, res) =>
         }
     })
 
-    //rename qualificationProjects to the parentProject
     const assignedProjects = foundAssignedProjects.map(({ qualificationProjects, ...rest }) => ({ ...rest, parentProject: qualificationProjects }))
 
     console.log("log from assigned_projects post ", { ...assignedProjects })
@@ -184,7 +181,6 @@ router.get("/:id/assigned_projects", parseId, async (req: RequestWithId, res) =>
 })
 
 router.get("/:id/single_assigned_project/:projectId", parseId, async (req: RequestWithId & { params: { projectId: any } }, res, next) => {
-    //table assigned_projects_for_students
     try {
         const projectId = req.params.projectId
         checkIds({ projectId }, NeededType.NUMBER)
@@ -253,7 +249,6 @@ router.post("/:id/qualification_title", parseId, async (req: RequestWithId, res,
             })
 
             if (student.qualificationTitleId) {
-                // revert previous title units
                 const previousTitleUnits = (await transaction.mandatoryQualificationUnitsForTitle.findMany({
                     where: {
                         titleId: student.qualificationTitleId
@@ -270,18 +265,6 @@ router.post("/:id/qualification_title", parseId, async (req: RequestWithId, res,
                 })
             }
 
-            // const titleUnits = await transaction.mandatoryQualificationUnitsForTitle.findMany({
-            //     where: { titleId: qualificationTitleId }
-            // })
-
-            // const qualificationUnitsToAssign = titleUnits.map(titleUnit => ({
-            //     studentId: req.id,
-            //     qualificationTitleId: titleUnit.unitId
-            // }))
-
-            // await transaction.assignedQualificationUnitsForStudent.createMany({
-            //     data: qualificationUnitsToAssign
-            // })
         })
 
         res.json({
@@ -296,7 +279,6 @@ router.post("/:id/qualification_title", parseId, async (req: RequestWithId, res,
 
 router.post("/assignProjectToStudent", async (req: RequestWithAssignProjectToStudentBody, res, next) => {
     try {
-        // console.log("assign to backend ", req.body.studentId, req.body.projectId)
         const { studentId, projectId } = req.body
 
         checkIds({ studentId, projectId }, NeededType.NUMBER)
@@ -359,7 +341,6 @@ router.post("/assignProjectToStudent", async (req: RequestWithAssignProjectToStu
         })
 
     } catch (error) {
-        // console.log("projectAssign error: ", error)
         next(error);
     }
 })
@@ -487,7 +468,6 @@ router.delete("/deleteWorktimeEntry", async (req, res, next) => {
 
 router.put("/updateStudentProject", async (req: RequestWithUpdateStudentProjectBody, res, next) => {
     try {
-        // console.log("updateProject: ", req.body)
         const { studentId, projectId, update } = req.body
 
         checkIds({ studentId, projectId }, NeededType.NUMBER)
@@ -570,13 +550,11 @@ router.put("/updateStudentProject", async (req: RequestWithUpdateStudentProjectB
 
         })
     } catch (error) {
-        // console.log("projectUpdate error: ", e)
         next(error)
     }
 })
 
 router.post("/:id/student_setup", parseId, async (req: StudentSetupWithIdRequest, res, next) => {
-    // console.log("setup test ", req.body, req.headers.authorization)
     try {
         const user = jwt.decode(req.headers.authorization) as DecodedJwtPayload;
         const { qualificationCompletion, qualificationId } = req.body;
@@ -595,8 +573,6 @@ router.post("/:id/student_setup", parseId, async (req: StudentSetupWithIdRequest
             if (user.isSetUp) {
                 throw new HttpError(401, "The student has already been set up.")
             }
-            // console.log("setup pre-student update ", qualificationCompletion, qualificationId, user.id)
-
             await prisma.$transaction(async (transaction) => {
                 await transaction.student.update({
                     where: { userId: userId },
@@ -606,7 +582,6 @@ router.post("/:id/student_setup", parseId, async (req: StudentSetupWithIdRequest
                     }
                 })
 
-                // assigning TVP for the new student, should make this more modular, if other vocations start using Ossi
                 if (qualificationCompletion === "FULL_COMPLETION") {
                     await transaction.assignedQualificationUnitsForStudent.create({
                         data: {
@@ -616,7 +591,6 @@ router.post("/:id/student_setup", parseId, async (req: StudentSetupWithIdRequest
                     })
                 }
 
-                // console.log("setup test pre-user update ")
                 await transaction.user.update({
                     where: { id: userId },
                     data: { isSetUp: true }

--- a/student-management-api/src/handlers/units-router.ts
+++ b/student-management-api/src/handlers/units-router.ts
@@ -79,7 +79,6 @@ router.post("/:id/part_order", parseId, async (req: RequestWithPartOrder, res, n
 
         const partIds = partOrder.map(Number)
 
-        // Validate that all elements in partOrder are numbers
         if (partIds.includes(NaN) || partOrder.includes("")) {
             throw new HttpError(400, "partOrder contains non-numeric values")
         }

--- a/student-management-api/src/index.ts
+++ b/student-management-api/src/index.ts
@@ -5,8 +5,6 @@ import { redisPublisher } from './redis.js';
 import prisma from 'prisma-orm';
 
 const main = async () => {
-    // we can presume qualification data from ePeruste is not yet, if there are no units in db
-
     if (await prisma.qualificationUnit.count() === 0) {
         const qualificationData = await getExternalQualificationData(7861752);
 

--- a/student-management-api/src/utils/checkIds.ts
+++ b/student-management-api/src/utils/checkIds.ts
@@ -6,14 +6,12 @@ export enum NeededType {
 }
 
 export const checkIds = (ids: Record<string, string | number | string[]> | string[], type: NeededType) => {
-  // If ids is an array
   if (Array.isArray(ids) && ids.length) {
     if (!ids.every((id) => typeof id === type || (type === NeededType.NUMBER && typeof id === "string" && !Number.isNaN(Number(id))))) {
       throw new HttpError(400, `some field is not of expected '${type}' type`);
     }
 
   } else if (typeof ids === "object" && ids !== null) {
-    // If ids is an object
     for (const key in ids) {
       const value = ids[key];
 

--- a/student-management-api/test/projects.test.ts
+++ b/student-management-api/test/projects.test.ts
@@ -13,7 +13,6 @@ beforeEach(async () => {
   const qualificationData = await getExternalQualificationData(7861752);
   await writePartsAndProjectsTestBaseData(qualificationData)
 
-  //await QualificationProjectTag.truncate({ cascade: true });
   await prisma.$queryRawUnsafe(`TRUNCATE TABLE "qualification_project_tags" RESTART IDENTITY CASCADE`)
   await prisma.qualificationProjectTag.createMany({ data: initialProjectTags });
 

--- a/student-management-api/test/test-helper.ts
+++ b/student-management-api/test/test-helper.ts
@@ -25,7 +25,6 @@ export const initialParts = [
   { unitOrderIndex: 6, name: 'Ohjelmointi Teema 3', description: 'Description', materials: '-', qualificationUnitId: 6816480 }
 ];
 
-// Define interfaces for the data structures
 interface QualificationData {
   units: any[];
   competenceRequirementGroups: any[];
@@ -49,7 +48,6 @@ export const writePartsAndProjectsTestBaseData = async (qualificationData: Quali
     await prisma.qualificationCompetenceRequirement.createMany({ data: qualificationData.competenceRequirements });
   }
 
-  // Delete all data from qualification_projects and qualification_unit_parts tables
   await prisma.$queryRawUnsafe(`TRUNCATE TABLE "qualification_projects" RESTART IDENTITY CASCADE`)
   await prisma.$queryRawUnsafe(`TRUNCATE TABLE "qualification_unit_parts" RESTART IDENTITY CASCADE`)
 


### PR DESCRIPTION
Lisäsin testikattavuutta auh-, gateway-, messaging- ja notification-palveluille: auth- ja GraphQL gateway -smoke-testit sekä messaging- ja notification-palveluihin integraatiotestit (Node:n oma test runner + supertest). Samalla lisäsin kaikille palveluille GET /health ja GET /ready endpointit, joissa readiness tarkistaa riippuvuuksien tilan (PostgreSQL/Prisma, MongoDB ja Redis palvelusta riippuen), jotta deployn tarkistus ja vianrajaus (Docker/Nginx) helpottuu. Päivitin dokumentaatiota (README + /docs) vastaamaan uusia testkomentoja ja endpointteja ja varmistin että backendin testit ajautuvat läpi (workspace-testit ja docker-pohjainen test stack). (pr on luotu)