### PR TITLE
feat: validate required env vars at service startup

### DIFF
--- a/api-gateway/src/env-bootstrap.ts
+++ b/api-gateway/src/env-bootstrap.ts
@@ -1,0 +1,9 @@
+import { assertRequiredEnv } from "./startup-env.js";
+
+assertRequiredEnv("api-gateway", [
+    "JWT_SECRET_KEY",
+    "INTERNAL_AUTH_API_URL",
+    "INTERNAL_STUDENT_MANAGEMENT_API_URL",
+    "INTERNAL_NOTIFICATION_SERVER_URL",
+    "INTERNAL_MESSAGING_SERVER_URL",
+]);

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,3 +1,4 @@
+import "./env-bootstrap.js";
 import { createApp } from "./app.js";
 import { publisher, redisClient, subscriber } from "./redis-client.js";
 

--- a/api-gateway/src/startup-env.ts
+++ b/api-gateway/src/startup-env.ts
@@ -1,0 +1,47 @@
+import dotenv from "dotenv";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function loadProjectEnv(): void {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+        path.join(process.cwd(), ".env"),
+        path.join(moduleDir, ".env"),
+        path.join(moduleDir, "..", ".env"),
+        path.join(moduleDir, "../../.env"),
+        path.join(moduleDir, "../../../.env"),
+    ];
+    for (const envPath of candidates) {
+        if (fs.existsSync(envPath)) {
+            dotenv.config({ path: envPath });
+        }
+    }
+}
+
+export function getMissingEnvKeys(keys: readonly string[]): string[] {
+    return keys.filter((key) => {
+        const value = process.env[key];
+        return value === undefined || String(value).trim() === "";
+    });
+}
+
+export function formatMissingEnvMessage(serviceLabel: string, missing: readonly string[]): string {
+    const list = missing.map((key) => `  - ${key}`).join("\n");
+    return [
+        `Error: ${serviceLabel} failed to start.`,
+        "Missing required environment variables (unset or empty):",
+        list,
+        "Set values in .env or the container environment.",
+    ].join("\n");
+}
+
+export function assertRequiredEnv(serviceLabel: string, keys: readonly string[]): void {
+    loadProjectEnv();
+    const missing = getMissingEnvKeys(keys);
+    if (missing.length === 0) {
+        return;
+    }
+    console.error(formatMissingEnvMessage(serviceLabel, missing));
+    process.exit(1);
+}

--- a/auth-api/src/env-bootstrap.ts
+++ b/auth-api/src/env-bootstrap.ts
@@ -1,0 +1,10 @@
+import { assertRequiredEnv } from "prisma-orm/validate-env";
+
+assertRequiredEnv("auth-api", [
+    "JWT_SECRET_KEY",
+    "SMTP_HOST",
+    "SMTP_PORT",
+    "SMTP_USER",
+    "SMTP_PASS",
+    "APP_URL",
+]);

--- a/auth-api/src/index.ts
+++ b/auth-api/src/index.ts
@@ -1,4 +1,4 @@
-import "dotenv";
+import "./env-bootstrap.js";
 import prisma from "prisma-orm";
 import { createApp } from "./app.js";
 

--- a/prisma-orm/index.ts
+++ b/prisma-orm/index.ts
@@ -1,12 +1,15 @@
-import "dotenv"
 import { PrismaClient } from "./generated/prisma/client.js";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { assertRequiredEnv } from "./validate-env.js";
 
-const DATABASE_URL = process.env.NODE_ENV === "test"
-  ? process.env.DATABASE_URL_TEST
-  : process.env.DATABASE_URL
+const dbUrlKey = process.env.NODE_ENV === "test" ? "DATABASE_URL_TEST" : "DATABASE_URL";
+assertRequiredEnv("prisma-orm", [dbUrlKey]);
 
-const adapter = new PrismaPg({ connectionString: DATABASE_URL })
+const DATABASE_URL = (
+    process.env.NODE_ENV === "test" ? process.env.DATABASE_URL_TEST : process.env.DATABASE_URL
+)!;
+
+const adapter = new PrismaPg({ connectionString: DATABASE_URL });
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient;

--- a/prisma-orm/package.json
+++ b/prisma-orm/package.json
@@ -33,6 +33,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./validate-env": {
+      "import": "./dist/validate-env.js",
+      "types": "./dist/validate-env.d.ts"
     }
   }
 }

--- a/prisma-orm/prisma.config.ts
+++ b/prisma-orm/prisma.config.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { defineConfig } from "prisma/config";
+import { resolveDatabaseUrl } from "./validate-env.js";
 
 export default defineConfig({
   schema: path.join("prisma", "schema.prisma"),
@@ -8,6 +9,6 @@ export default defineConfig({
     seed: "tsx prisma/seed.ts",
   },
   datasource: {
-    url: process.env.DATABASE_URL!,
+    url: resolveDatabaseUrl(),
   }
 })

--- a/prisma-orm/prisma/prisma.config.ts
+++ b/prisma-orm/prisma/prisma.config.ts
@@ -1,11 +1,8 @@
 import { defineConfig } from 'prisma/config';
-
-if (!process.env.DATABASE_URL) {
-  throw new Error('DATABASE_URL is not set');
-}
+import { resolveDatabaseUrl } from '../validate-env.js';
 
 export default defineConfig({
   datasource: {
-    url: process.env.DATABASE_URL as string,
+    url: resolveDatabaseUrl('prisma'),
   },
 });

--- a/prisma-orm/tsconfig.json
+++ b/prisma-orm/tsconfig.json
@@ -27,6 +27,7 @@
   },
   "include": [
     "index.ts",
+    "validate-env.ts",
     "prisma/**/*.ts",
     "generated/**/*.ts",
     "prisma.config.ts"

--- a/prisma-orm/validate-env.ts
+++ b/prisma-orm/validate-env.ts
@@ -1,0 +1,69 @@
+import dotenv from "dotenv";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PRISMA_GENERATE_PLACEHOLDER_URL =
+    "postgresql://prisma-generate:prisma-generate@127.0.0.1:5432/prisma_generate";
+
+export function isPrismaGenerateCommand(): boolean {
+    return process.argv.some((arg) => arg === "generate" || arg.endsWith("/generate"));
+}
+
+export function loadProjectEnv(): void {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+        path.join(process.cwd(), ".env"),
+        path.join(moduleDir, ".env"),
+        path.join(moduleDir, "..", ".env"),
+        path.join(moduleDir, "../..", ".env"),
+    ];
+    for (const envPath of candidates) {
+        if (fs.existsSync(envPath)) {
+            dotenv.config({ path: envPath });
+        }
+    }
+}
+
+export function getMissingEnvKeys(keys: readonly string[]): string[] {
+    return keys.filter((key) => {
+        const value = process.env[key];
+        return value === undefined || String(value).trim() === "";
+    });
+}
+
+export function formatMissingEnvMessage(serviceLabel: string, missing: readonly string[]): string {
+    const list = missing.map((key) => `  - ${key}`).join("\n");
+    return [
+        `Error: ${serviceLabel} failed to start.`,
+        "Missing required environment variables (unset or empty):",
+        list,
+        "Set values in .env or the container environment.",
+    ].join("\n");
+}
+
+export function assertRequiredEnv(serviceLabel: string, keys: readonly string[]): void {
+    loadProjectEnv();
+    const missing = getMissingEnvKeys(keys);
+    if (missing.length === 0) {
+        return;
+    }
+    console.error(formatMissingEnvMessage(serviceLabel, missing));
+    process.exit(1);
+}
+
+export function resolveDatabaseUrl(serviceLabel = "prisma-migrations"): string {
+    loadProjectEnv();
+    const url = process.env.DATABASE_URL?.trim();
+    if (url) {
+        return url;
+    }
+    if (isPrismaGenerateCommand()) {
+        return PRISMA_GENERATE_PLACEHOLDER_URL;
+    }
+    const missing = getMissingEnvKeys(["DATABASE_URL"]);
+    if (missing.length > 0) {
+        throw new Error(formatMissingEnvMessage(serviceLabel, missing));
+    }
+    return process.env.DATABASE_URL!;
+}


### PR DESCRIPTION
Lisäsin käynnistysvaiheen tarkistus pakollisille ympäristömuuttujille. Jos jokin puuttuu tai on tyhjä, palvelu kaatuu heti ja heittää error viestin

Miksi
Ennen Tuotannossa ja deployssa puuttuvat .env-arvot (esim. DATABASE_URL, JWT_SECRET_KEY, INTERNAL_*_URL) ovat aiheuttaneet epäselviä virheitä vasta myöhemmin. Tavoite on havaita konf-ongelmat heti käynnistyksessä.